### PR TITLE
Fix/content entry input items

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -10,7 +10,7 @@
                    slipset/deps-deploy {:mvn/version "0.2.2"}}
                   :ns-default slim.lib
                   :exec-args {:lib         com.github.brianium/oai-clj
-                              :version     "2.0.0.1"
+                              :version     "2.0.0.2"
                               :url         "https://github.com/brianium/oai-clj"
                               :description "Just a little Clojure sugar on top of openai-java"
                               :developer   "Brian Scaturro"}}}}

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -68,7 +68,7 @@
   ;;; Mixing and matching is much easier with :input-items
   (def response
     (oai/create-response
-     :input-items [{:role :system :content "You are an art critic specializing in cartoon turtles"}
+     :input-items [{:role :system :content ["You are an art critic specializing in cartoon turtles"]}
                    {:role :user :content "I am going to show you some art. Be honest. Before you give your review, start with \"Here we go again.\""}
                    {:role :assistant :content "Understood"}
                    {:role :user :content ["Give it to me straight, what do you think of this?"

--- a/src/oai_clj/models/responses.clj
+++ b/src/oai_clj/models/responses.clj
@@ -187,7 +187,7 @@
   ```"
   [entries]
   (letfn [(content-entry? [m]
-            (and (contains? m :role) (= :user (:role m)) (not (string? (:content m)))))
+            (and (contains? m :role) (not= :assistant (:role m)) (not (string? (:content m)))))
           (easy-input-entry? [m]
             (and (contains? m :role) (string? (:content m))))
           (output-message? [m]


### PR DESCRIPTION
content items support roles of `:user`, `:developer` and `:system`. I may just want to make this a check for the vector content payload. This does the trick for now.